### PR TITLE
Add function and key binding for flow get-imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Shows a diff for the current file with missing types inferred.
 
 Shortcut: `C-t`
 
+### flow-get-imports
+
+Shows the imports of the current file.
+
+Shortcut: `C-t C-i`
+
 ### flow-get-def
 
 Shows where the reference at the current point is defined.

--- a/flow.el
+++ b/flow.el
@@ -112,6 +112,21 @@
 
 (global-set-key (kbd "M-.") 'flow-get-def)
 
+(defun flow-get-imports ()
+  "get imports for current file"
+  (interactive)
+  (let ((file (buffer-file-name)))
+    (switch-to-buffer-other-window "*Shell Command Output*")
+    (flow-start)
+    (shell-command
+     (format "%s get-imports --from emacs %s"
+             flow_binary
+             file))
+    (compilation-mode))
+)
+
+(global-set-key (kbd "C-c C-i") 'flow-get-def)
+
 (defun flow-autocomplete ()
   "autocomplete"
   (interactive)


### PR DESCRIPTION
Not sure if this is still widely used by anyone, but I added support for the `get-imports` command locally and I thought I'd push it upstream in case it was useful to anyone else.

---

This runs "flow get-imports" on the current file and shows the result in
a compilation output buffer.

The keybinding it set to `C-c C-i`