### PR TITLE
Adopt more Emacslike conventions; bind commands to dedicated keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ containing the current file (unless already started). Likewise, when you exit
 the editor, the Flow server for the project containing the current file is
 stopped.
 
-### flow-status
+### flow/status
 
 Shows a list of current errors. 
 
-Shortcut: `C-x RET`
+Shortcut: `C-c C-s`
 
-### flow-type-at-pos
+### flow/type-at-pos
 
 Shows the type of the expression at the current point.
 
@@ -44,7 +44,7 @@ Shortcut: `C-c C-t`
 
 Shows a diff for the current file with missing types inferred.
 
-Shortcut: `C-t`
+Shortcut: `C-c C-/`
 
 ### flow-get-def
 

--- a/flow.el
+++ b/flow.el
@@ -9,7 +9,7 @@
 
 (defvar flow-mode-map (make-sparse-keymap))
 
-(setq flow/binary "flow")
+(defvar flow/binary "flow")
 
 (defun flow/column-number-at-pos (pos)
   "column number at pos"

--- a/flow.el
+++ b/flow.el
@@ -39,6 +39,8 @@
   (flow/start)
   (compile (format "%s status --from emacs; exit 0" flow/binary)))
 
+(define-key flow-mode-map (kbd "C-c C-s") #'flow/status)
+
 (defun flow/type-at-pos ()
   "show type"
   (interactive)
@@ -57,6 +59,8 @@
     (compilation-mode)
     (switch-to-buffer-other-window buffer)))
 
+(define-key flow-mode-map (kbd "C-c C-t") #'flow/type-at-pos)
+
 (defun flow/suggest ()
   "fill types"
   (interactive)
@@ -72,6 +76,8 @@
              region))
     (compilation-mode)
     (switch-to-buffer-other-window buffer)))
+
+(define-key flow-mode-map (kbd "C-c C-/") #'flow-suggest)
 
 (defun flow/goto-definition ()
   "jump to definition"
@@ -89,6 +95,8 @@
              line
              (1+ col)))
     (compilation-mode)))
+
+(define-key flow-mode-map (kbd "M-.") #'flow/goto-definition)
 
 (defun flow/autocomplete ()
   "autocomplete"
@@ -109,12 +117,7 @@
     (compilation-mode)
     (switch-to-buffer-other-window buffer)))
 
-(bind-keys :map flow-mode-map
-           ("M-." . flow/goto-definition)
-           ("C-c C-/" . flow-suggest)
-           ("C-c C-t" . flow/type-at-pos)
-           ("C-c C-s" . flow/status)
-           ("M-TAB" . flow/autocomplete))
+(define-key flow-mode-map (kbd "M-TAB") #'flow/autocomplete)
 
 (define-minor-mode flow-mode
   "Minor mode for working with JavaScript Flow types."

--- a/flow.el
+++ b/flow.el
@@ -7,52 +7,39 @@
 ;; rights can be found in the PATENTS file in the same directory.
 ;;
 
-(setq flow_binary "flow")
+(defvar flow-mode-map (make-sparse-keymap))
 
-(defun column-number-at-pos (pos)
+(setq flow/binary "flow")
+
+(defun flow/column-number-at-pos (pos)
   "column number at pos"
-  (save-excursion (goto-char pos) (current-column))
-)
+  (save-excursion (goto-char pos) (current-column)))
 
-(defun string-of-region ()
+(defun flow/string-of-region ()
   "string of region"
   (if (use-region-p)
       (let ((begin (region-beginning))
             (end (region-end)))
         (format ":%d:%d,%d:%d"
                 (line-number-at-pos begin)
-                (column-number-at-pos begin)
+                (flow/column-number-at-pos begin)
                 (line-number-at-pos end)
-                (column-number-at-pos end)))
-    "")
-)
+                (flow/column-number-at-pos end)))
+    ""))
 
-(defun get-assoc-value (key alist)
-  "get assoc value"
-  (setq blah (assoc key alist))
-  (if blah
-      (cdr blah)
-    nil)
-)
+(defun flow/start ()
+  (shell-command (format "%s start" flow/binary)))
 
-(defun flow-start ()
-  (shell-command (format "%s start" flow_binary))
-)
+(defun flow/stop ()
+  (shell-command (format "%s stop" flow/binary)))
 
-(defun flow-stop ()
-  (shell-command (format "%s stop" flow_binary))
-)
-
-(defun flow-status ()
+(defun flow/status ()
   "Initialize flow"
   (interactive)
-  (flow-start)
-  (compile (format "%s status --from emacs; exit 0" flow_binary))
-)
+  (flow/start)
+  (compile (format "%s status --from emacs; exit 0" flow/binary)))
 
-(global-set-key (kbd "C-x C-m") 'flow-status)
-
-(defun flow-type-at-pos ()
+(defun flow/type-at-pos ()
   "show type"
   (interactive)
   (let ((file (buffer-file-name))
@@ -60,39 +47,33 @@
         (col (current-column))
         (buffer (current-buffer)))
     (switch-to-buffer-other-window "*Shell Command Output*")
-    (flow-start)
+    (flow/start)
     (shell-command
      (format "%s type-at-pos --from emacs %s %d %d"
-             flow_binary
+             flow/binary
              file
              line
              (1+ col)))
     (compilation-mode)
-    (switch-to-buffer-other-window buffer))
-)
+    (switch-to-buffer-other-window buffer)))
 
-(global-set-key (kbd "C-c C-t") 'flow-type-at-pos)
-
-(defun flow-suggest ()
+(defun flow/suggest ()
   "fill types"
   (interactive)
   (let ((file (buffer-file-name))
-        (region (string-of-region))
+        (region (flow/string-of-region))
         (buffer (current-buffer)))
     (switch-to-buffer-other-window "*Shell Command Output*")
-    (flow-start)
+    (flow/start)
     (shell-command
      (format "%s suggest %s%s"
-             flow_binary
+             flow/binary
              file
              region))
     (compilation-mode)
-    (switch-to-buffer-other-window buffer))
-)
+    (switch-to-buffer-other-window buffer)))
 
-(global-set-key (kbd "C-t") 'flow-suggest)
-
-(defun flow-get-def ()
+(defun flow/goto-definition ()
   "jump to definition"
   (interactive)
   (let ((file (buffer-file-name))
@@ -100,19 +81,16 @@
         (col (current-column))
         (buffer (current-buffer)))
     (switch-to-buffer-other-window "*Shell Command Output*")
-    (flow-start)
+    (flow/start)
     (shell-command
      (format "%s get-def --from emacs %s %d %d"
-             flow_binary
+             flow/binary
              file
              line
              (1+ col)))
-    (compilation-mode))
-)
+    (compilation-mode)))
 
-(global-set-key (kbd "M-.") 'flow-get-def)
-
-(defun flow-autocomplete ()
+(defun flow/autocomplete ()
   "autocomplete"
   (interactive)
   (let ((file (buffer-file-name))
@@ -120,20 +98,37 @@
         (col (current-column))
         (buffer (current-buffer)))
     (switch-to-buffer-other-window "*Shell Command Output*")
-    (flow-start)
+    (flow/start)
     (shell-command
      (format "%s autocomplete %s %d %d < %s"
-             flow_binary
+             flow/binary
              file
              line
              (1+ col)
              file))
     (compilation-mode)
-    (switch-to-buffer-other-window buffer))
-)
+    (switch-to-buffer-other-window buffer)))
 
-(global-set-key (kbd "M-TAB") 'flow-autocomplete)
+(bind-keys :map flow-mode-map
+           ("M-." . flow/goto-definition)
+           ("C-c C-/" . flow-suggest)
+           ("C-c C-t" . flow/type-at-pos)
+           ("C-c C-s" . flow/status)
+           ("M-TAB" . flow/autocomplete))
+
+(define-minor-mode flow-mode
+  "Minor mode for working with JavaScript Flow types."
+  :init-value nil
+  :lighter " Flow"
+  :keymap flow-mode-map)
+
+(defun flow/maybe-start ()
+  (interactive)
+  (save-excursion
+    (goto-char 1)
+    (when (looking-at "^[[:space:]]*/[*/][[:space:]]*@flow")
+      (flow-mode t))))
 
 (add-hook 'kill-emacs-hook
   (lambda ()
-    (flow-stop)))
+    (flow/stop)))


### PR DESCRIPTION
These commands are better suited for a minor mode that hooks into the JS mode of the user's choice than for global keybindings, so I created a minor mode.